### PR TITLE
support https://github.com

### DIFF
--- a/pkg/variantmod/manager.go
+++ b/pkg/variantmod/manager.go
@@ -600,6 +600,7 @@ func (m *ModuleManager) PullRequest(title, base, head string) error {
 	p := strings.TrimSpace(push)
 	p = strings.TrimSuffix(p, ".git")
 	p = strings.TrimPrefix(p, "git@github.com:")
+	p = strings.TrimPrefix(p, "https://github.com/")
 	ownerRepo := strings.Split(p, "/")
 	if len(ownerRepo) != 2 {
 		return fmt.Errorf("unexpected format of remote: %s", push)


### PR DESCRIPTION
There was a problem working mod with Github Action.
https://github.com/cw-ozaki/github-action-test/commit/aefc1e7308f83db9e3be5c13f95440c10deabd44/checks

> ```
> unexpected format of remote: https://github.com/cw-ozaki/github-action-test\n
> ```

The problem is because the code is only trimmed `git@github.com:`.