### PR TITLE
fixes textReplace changes not being pushed

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -88,7 +88,7 @@ func Execute() {
 		if err := man.Up(); err != nil {
 			return err
 		}
-		files := []string{"variant.mod"}
+		files := []string{"variant.mod", "variant.lock"}
 		ts := time.Now().Format("20060102150405")
 		branch = fmt.Sprintf("%s-%s", branch, ts)
 		if push {
@@ -101,7 +101,7 @@ func Execute() {
 			if err != nil {
 				return err
 			}
-			files = r.Files
+			files = append(files, r.Files...)
 		}
 		var pushed bool
 		if push {

--- a/pkg/variantmod/manager.go
+++ b/pkg/variantmod/manager.go
@@ -905,6 +905,8 @@ func (m *ModuleManager) doBuildSingle(mod *Module) (r *BuildResult, err error) {
 			m.Logger.V(1).Info(err.Error())
 			return nil, err
 		}
+
+		r.Files = append(r.Files, t.Path)
 	}
 
 	return r, nil


### PR DESCRIPTION
https://github.com/chatwork/dockerfiles/pull/116
https://github.com/chatwork/dockerfiles/runs/245537081
We have found an issue that only push files that have been modified in files provisioner.
I think textReplace provisioner and `variant.lock` should also push, so I fixed it that way.