### PR TITLE
Add yamlPatch provisioner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,15 @@ require (
 	github.com/Masterminds/semver v1.4.2
 	github.com/PaesslerAG/gval v1.0.1 // indirect
 	github.com/PaesslerAG/jsonpath v0.1.0
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/protobuf v1.3.1 // indirect
-	github.com/google/go-cmp v0.3.0 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/google/go-github/v27 v27.0.4
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-getter v1.3.0
+	github.com/kylelemons/godebug v1.1.0
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/twpayne/go-vfs v1.2.0
@@ -21,10 +24,9 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
 	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
+	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
 	k8s.io/klog v0.3.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -34,6 +33,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
+github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -96,6 +97,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -114,6 +117,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -257,12 +262,10 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=
-gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555 h1:4Yrwvx9yMvZx+vK3wdX7aX2UCNZJJn0TDc+BNOJTE00=
+gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/releasetracker/tracker.go
+++ b/pkg/releasetracker/tracker.go
@@ -500,7 +500,7 @@ func (p *Tracker) extractVersionStrings(tmp interface{}, jpath string) ([]string
 func (p *Tracker) versionStringsToSemvers(vs []string) ([]*semver.Version, error) {
 	vss := []*semver.Version{}
 	for i, s := range vs {
-		v, err := semver.NewVersion(s)
+		v, err := semver.NewVersion(strings.TrimSpace(s))
 		if err != nil {
 			e := fmt.Errorf("parsing version: index %d: %q: %v", i, s, err)
 			p.Logger.V(1).Info("ignoring error", "err", e)

--- a/pkg/variantmod/manager.go
+++ b/pkg/variantmod/manager.go
@@ -3,6 +3,7 @@ package variantmod
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/google/go-github/v27/github"
@@ -14,6 +15,7 @@ import (
 	"github.com/variantdev/mod/pkg/maputil"
 	"github.com/variantdev/mod/pkg/releasetracker"
 	"github.com/variantdev/mod/pkg/tmpl"
+	"github.com/variantdev/mod/pkg/yamlpatch"
 	"github.com/xeipuuv/gojsonschema"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
@@ -42,6 +44,7 @@ type ProvisionersSpec struct {
 	Files       map[string]FileSpec        `yaml:"files"`
 	Executables execversionmanager.Config  `yaml:",inline"`
 	TextReplace map[string]TextReplaceSpec `yaml:"textReplace"`
+	Yaml        map[string][]YamlSpec      `yaml:"yaml"`
 }
 
 type FileSpec struct {
@@ -52,6 +55,13 @@ type FileSpec struct {
 type TextReplaceSpec struct {
 	From string `yaml:"from"`
 	To   string `yaml:"to"`
+}
+
+type YamlSpec struct {
+	Op string `yaml:"op"`
+	Path string `yaml:"path"`
+	Value interface{} `yaml:"value"`
+	From string `yaml:"string"`
 }
 
 type DependencySpec struct {
@@ -476,6 +486,25 @@ func (m *ModuleManager) load(depspec DependencySpec) (mod *Module, err error) {
 		textReplaces = append(textReplaces, t)
 	}
 
+	yamls := []Yaml{}
+	for path, yspec := range spec.Provisioners.Yaml {
+		patches := []YamlPatch{}
+		for _, v := range yspec {
+			p := YamlPatch{
+				Op: v.Op,
+				Path: v.Path,
+				Value: v.Value,
+				From: v.From,
+			}
+			patches = append(patches, p)
+		}
+		y := Yaml{
+			Path: path,
+			Patches: patches,
+		}
+		yamls = append(yamls, y)
+	}
+
 	spec.Parameters.Schema["type"] = "object"
 
 	execset, err := execversionmanager.New(
@@ -510,6 +539,7 @@ func (m *ModuleManager) load(depspec DependencySpec) (mod *Module, err error) {
 		ValuesSchema:    schema,
 		Files:           files,
 		TextReplaces:    textReplaces,
+		Yamls:           yamls,
 		Executable:      execset,
 		Submodules:      submods,
 		ReleaseTrackers: trackers,
@@ -908,6 +938,57 @@ func (m *ModuleManager) doBuildSingle(mod *Module) (r *BuildResult, err error) {
 		}
 
 		r.Files = append(r.Files, t.Path)
+	}
+
+	for _, y := range mod.Yamls {
+		path, err := tmpl.Render("path", y.Path, values)
+		if err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+
+		target := filepath.Join(m.AbsWorkDir, path)
+		contents, err := m.fs.ReadFile(target)
+		if err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+
+		out, err := json.Marshal(y.Patches)
+		if err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+		patchJSON, err := tmpl.Render("patches", string(out), values)
+		if err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+
+		var yml yaml.Node
+		if err := yaml.Unmarshal(contents, &yml); err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+
+		var v interface{}
+		if err := yml.Decode(&v); err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+		yamlpatch.Patch(&yml, patchJSON)
+
+		s, err := yaml.Marshal(yml.Content[0])
+		if err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+
+		if err := m.fs.WriteFile(target, s, 0644); err != nil {
+			m.Logger.V(1).Info(err.Error())
+			return nil, err
+		}
+		r.Files = append(r.Files, y.Path)
 	}
 
 	return r, nil

--- a/pkg/variantmod/manager.go
+++ b/pkg/variantmod/manager.go
@@ -44,7 +44,7 @@ type ProvisionersSpec struct {
 	Files       map[string]FileSpec        `yaml:"files"`
 	Executables execversionmanager.Config  `yaml:",inline"`
 	TextReplace map[string]TextReplaceSpec `yaml:"textReplace"`
-	Yaml        map[string][]YamlSpec      `yaml:"yaml"`
+	YamlPatch   map[string][]YamlPatchSpec `yaml:"yamlPatch"`
 }
 
 type FileSpec struct {
@@ -57,7 +57,7 @@ type TextReplaceSpec struct {
 	To   string `yaml:"to"`
 }
 
-type YamlSpec struct {
+type YamlPatchSpec struct {
 	Op string `yaml:"op"`
 	Path string `yaml:"path"`
 	Value interface{} `yaml:"value"`
@@ -486,11 +486,11 @@ func (m *ModuleManager) load(depspec DependencySpec) (mod *Module, err error) {
 		textReplaces = append(textReplaces, t)
 	}
 
-	yamls := []Yaml{}
-	for path, yspec := range spec.Provisioners.Yaml {
-		patches := []YamlPatch{}
+	yamls := []YamlPatch{}
+	for path, yspec := range spec.Provisioners.YamlPatch {
+		patches := []Patch{}
 		for _, v := range yspec {
-			p := YamlPatch{
+			p := Patch{
 				Op: v.Op,
 				Path: v.Path,
 				Value: v.Value,
@@ -498,7 +498,7 @@ func (m *ModuleManager) load(depspec DependencySpec) (mod *Module, err error) {
 			}
 			patches = append(patches, p)
 		}
-		y := Yaml{
+		y := YamlPatch{
 			Path: path,
 			Patches: patches,
 		}

--- a/pkg/variantmod/module.go
+++ b/pkg/variantmod/module.go
@@ -17,7 +17,7 @@ type Module struct {
 	ValuesSchema Values
 	Files        []File
 	TextReplaces []TextReplace
-	Yamls        []Yaml
+	Yamls        []YamlPatch
 
 	ReleaseChannel *releasetracker.Tracker
 	Executable     *execversionmanager.ExecVM
@@ -64,16 +64,16 @@ type TextReplace struct {
 	From, To string
 }
 
-type Yaml struct {
+type YamlPatch struct {
 	Path    string
-	Patches []YamlPatch
+	Patches []Patch
 }
 
-type YamlPatch struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
+type Patch struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
 	Value interface{} `json:"value"`
-	From  string `json:"from"`
+	From  string      `json:"from"`
 }
 
 func merge(src, dst map[string]struct{}) {

--- a/pkg/variantmod/module.go
+++ b/pkg/variantmod/module.go
@@ -17,6 +17,7 @@ type Module struct {
 	ValuesSchema Values
 	Files        []File
 	TextReplaces []TextReplace
+	Yamls        []Yaml
 
 	ReleaseChannel *releasetracker.Tracker
 	Executable     *execversionmanager.ExecVM
@@ -61,6 +62,18 @@ type File struct {
 type TextReplace struct {
 	Path     string
 	From, To string
+}
+
+type Yaml struct {
+	Path    string
+	Patches []YamlPatch
+}
+
+type YamlPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value interface{} `json:"value"`
+	From  string `json:"from"`
 }
 
 func merge(src, dst map[string]struct{}) {

--- a/pkg/yamlpatch/patch.go
+++ b/pkg/yamlpatch/patch.go
@@ -1,0 +1,41 @@
+package yamlpatch
+
+import (
+	"encoding/json"
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func Patch(y *yaml.Node, patchJSON string) error {
+	var v1 interface{}
+	if err := y.Decode(&v1); err != nil {
+		return err
+	}
+
+	origJson, err := json.Marshal(v1)
+	if err != nil {
+		return err
+	}
+
+	patch, err := jsonpatch.DecodePatch([]byte(patchJSON))
+	if err != nil {
+		return err
+	}
+
+	modified, err := patch.Apply(origJson)
+	if err != nil {
+		return err
+	}
+
+	var v2 interface{}
+	if err := json.Unmarshal(modified, &v2); err != nil {
+		return err
+	}
+
+	t := &Traversal{stack:[]interface{}{}}
+	t.pushState(y, nil, "$")
+	cmp.Equal(v1, v2, cmp.Reporter(t))
+
+	return nil
+}

--- a/pkg/yamlpatch/patch_test.go
+++ b/pkg/yamlpatch/patch_test.go
@@ -1,0 +1,365 @@
+package yamlpatch_test
+
+import (
+	"github.com/kylelemons/godebug/diff"
+	_ "github.com/kylelemons/godebug/diff"
+	"github.com/variantdev/mod/pkg/yamlpatch"
+	"gopkg.in/yaml.v3"
+	"strings"
+	"testing"
+)
+
+func Patch(yml string, jsonPatch string, expected string) string {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yml), &node); err != nil {
+		panic(err)
+	}
+
+	if err := yamlpatch.Patch(&node, jsonPatch); err != nil {
+		panic(err)
+	}
+
+	out, err := yaml.Marshal(node.Content[0])
+	if err != nil {
+		panic(err)
+	}
+
+	if strings.TrimSpace(expected) != strings.TrimSpace(string(out)) {
+		return diff.Diff(strings.TrimSpace(expected), strings.TrimSpace(string(out)))
+	}
+
+	return ""
+}
+
+func TestPatch_AddScalarToSeqIndex(t *testing.T) {
+	yml := `
+foo:
+  - 1
+  - 2
+  - 3
+`
+	patch := `[{"op": "add", "path": "/foo/1", "value": 4}]`
+	expected := `
+foo:
+  - 1
+  - 4
+  - 2
+  - 3
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddSeqToSeqIndex(t *testing.T) {
+	yml := `
+foo:
+  - 1
+  - 2
+  - 3
+`
+	patch := `[{"op": "add", "path": "/foo/1", "value": [1, 2, 3]}]`
+	expected := `
+foo:
+  - 1
+  - [1, 2, 3]
+  - 2
+  - 3
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddMapToSeqIndex(t *testing.T) {
+	yml := `
+foo:
+  - 1
+  - 2
+  - 3
+`
+	patch := `[{"op": "add", "path": "/foo/1", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `
+foo:
+  - 1
+  - {"a": 1, "b": 2, "c": 3}
+  - 2
+  - 3
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddScalarToEmpty(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/bar", "value": 2}]`
+	expected := `
+foo: 1
+bar: 2
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddSeqToEmpty(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/bar", "value": [1, 2, 3]}]`
+	expected := `
+foo: 1
+bar:
+  - 1
+  - 2
+  - 3
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddMapToEmpty(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/bar", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `
+foo: 1
+bar:
+    a: 1
+    b: 2
+    c: 3
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddScalarToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/foo", "value": 2}]`
+	expected := `foo: 2`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddSecToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/foo", "value": [1, 2, 3]}]`
+	expected := `foo: [1, 2, 3]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_AddMapToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "add", "path": "/foo", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `foo: {"a": 1, "b": 2, "c": 3}`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_RemoveScalar(t *testing.T) {
+	yml := `
+foo: 1
+bar: 2
+`
+	patch := `[{"op": "remove", "path": "/foo"}]`
+	expected := `bar: 2`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_RemoveSeq(t *testing.T) {
+	yml := `
+foo:
+  - 1
+  - 2
+  - 3
+bar: 2
+`
+	patch := `[{"op": "remove", "path": "/foo"}]`
+	expected := `bar: 2`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_RemoveSeqIndex(t *testing.T) {
+	yml := `
+foo:
+  - 1
+  - 2
+  - 3
+bar: 2
+`
+	patch := `[{"op": "remove", "path": "/foo/0"}]`
+	expected := `
+foo:
+  - 2
+  - 3
+bar: 2
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_RemoveMap(t *testing.T) {
+	yml := `
+foo:
+    a: 1
+    b: 2
+    c: 3
+bar: 2
+`
+	patch := `[{"op": "remove", "path": "/foo"}]`
+	expected := `bar: 2`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_RemoveKey(t *testing.T) {
+	yml := `
+foo:
+    a: 1
+    b: 2
+    c: 3
+bar: 2
+`
+	patch := `[{"op": "remove", "path": "/foo/b"}]`
+	expected := `
+foo:
+    a: 1
+    c: 3
+bar: 2`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceScalarToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "replace", "path": "/foo", "value": 1.5}]`
+	expected := `foo: 1.5`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceSeqToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "replace", "path": "/foo", "value": [1, 2, 3]}]`
+	expected := `foo: [1, 2, 3]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceMapToScalar(t *testing.T) {
+	yml := `foo: 1`
+	patch := `[{"op": "replace", "path": "/foo", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `foo: {"a": 1, "b": 2, "c": 3}`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceScalarToSeq(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo", "value": 1.5}]`
+	expected := `foo: 1.5`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceSeqToSeq(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo", "value": [3, 4, 5]}]`
+	expected := `foo: [3, 4, 5]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceMapToSeq(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `foo: {"a": 1, "b": 2, "c": 3}`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceScalarToSeqIndex(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo/0", "value": 1.5}]`
+	expected := `foo: [1.5, 2, 3]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceSeqToSeqIndex(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo/0", "value": [3, 4, 5]}]`
+	expected := `foo: [[3, 4, 5], 2, 3]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceMapToSeqIndex(t *testing.T) {
+	yml := `foo: [1, 2, 3]`
+	patch := `[{"op": "replace", "path": "/foo/0", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `foo: [{"a": 1, "b": 2, "c": 3}, 2, 3]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceScalarToMap(t *testing.T) {
+	yml := `foo: {"a": 1, "b": 2, "c": 3}`
+	patch := `[{"op": "replace", "path": "/foo", "value": 1.5}]`
+	expected := `foo: 1.5`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceSeqToMap(t *testing.T) {
+	yml := `foo: {"a": 1, "b": 2, "c": 3}`
+	patch := `[{"op": "replace", "path": "/foo", "value": [3, 4, 5]}]`
+	expected := `foo: [3, 4, 5]`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_ReplaceMapToMap(t *testing.T) {
+	yml := `foo: {"a": 1, "b": 2, "c": 3}`
+	patch := `[{"op": "replace", "path": "/foo", "value": {"a": 1, "b": 2, "c": 3}}]`
+	expected := `foo: {"a": 1, "b": 2, "c": 3}`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}
+
+func TestPatch_NotRemoveComment(t *testing.T) {
+	yml := `
+# FOO
+foo: 1
+`
+	patch := `[{"op": "add", "path": "/foo", "value": 2}]`
+	expected := `
+# FOO
+foo: 2
+`
+	if d := Patch(yml, patch, expected); d != "" {
+		t.Fatalf("\n%s", d)
+	}
+}

--- a/pkg/yamlpatch/traversal.go
+++ b/pkg/yamlpatch/traversal.go
@@ -1,0 +1,160 @@
+package yamlpatch
+
+import (
+	"encoding/json"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+	"strconv"
+)
+
+type TraversalState struct {
+	yml *yaml.Node
+	ps cmp.PathStep
+	key string
+}
+
+type Traversal struct {
+	stack []interface{}
+}
+
+func (t *Traversal) pushState(yml *yaml.Node, ps cmp.PathStep, key string) {
+	t.stack = append(t.stack, TraversalState {
+		yml: yml,
+		ps: ps,
+		key: key,
+	})
+}
+
+func (t *Traversal) popState() (yml *yaml.Node, ps cmp.PathStep, key string) {
+	v := t.stack[len(t.stack) - 1].(TraversalState)
+	t.stack = t.stack[:len(t.stack) - 1]
+	return v.yml, v.ps, v.key
+}
+
+func (t *Traversal) state() (yml *yaml.Node, ps cmp.PathStep, key string) {
+	v := t.stack[len(t.stack) - 1].(TraversalState)
+	return v.yml, v.ps, v.key
+}
+
+func (t *Traversal) parentState() (yml *yaml.Node, ps cmp.PathStep, key string) {
+	l := len(t.stack) - 2
+	if l < 0 {
+		return nil, nil, ""
+	}
+	v := t.stack[len(t.stack) - 2].(TraversalState)
+	return v.yml, v.ps, v.key
+}
+
+func (t *Traversal) PushStep(ps cmp.PathStep) {
+	yml, pss, _ := t.state()
+
+	switch p := ps.(type) {
+	case cmp.SliceIndex:
+		index := p.Key()
+		if 0 <= index && index < len(yml.Content) {
+			t.pushState(yml.Content[index], ps, strconv.Itoa(index))
+		} else {
+			_, ykey := p.SplitKeys()
+			t.pushState(yml, ps, strconv.Itoa(ykey))
+		}
+	case cmp.MapIndex:
+		index := -1
+		for i, n := range yml.Content {
+			if i % 2 > 0 {
+				continue
+			}
+			if n.Value == p.Key().String() {
+				index = i + 1
+				break
+			}
+		}
+		if index == -1 {
+			t.pushState(yml, ps, p.Key().String())
+		} else {
+			t.pushState(yml.Content[index], ps, p.Key().String())
+		}
+	case cmp.TypeAssertion:
+		t.pushState(yml, pss, "_")
+	case cmp.PathStep:
+		t.pushState(yml.Content[0], ps, "$")
+	}
+}
+
+func (t *Traversal) Report(rs cmp.Result) {
+	yml, ps, key := t.state()
+	parent, _, _ := t.parentState()
+	vx, vy := ps.Values()
+
+	if vx.IsValid() && vy.IsValid() {
+		// modify
+		out, _ := json.Marshal(vy.Interface())
+		var node yaml.Node
+		yaml.Unmarshal(out, &node)
+		yml.Kind = node.Content[0].Kind
+		yml.Style = node.Content[0].Style
+		yml.Tag = node.Content[0].Tag
+		yml.Value = node.Content[0].Value
+		yml.Content = node.Content[0].Content
+
+	} else if vx.IsValid() && !vy.IsValid() {
+		// remove
+		switch parent.Kind {
+		case yaml.DocumentNode:
+			parent.Content = []*yaml.Node{}
+		case yaml.SequenceNode:
+			// Always delete the last element
+			parent.Content = parent.Content[:len(parent.Content) - 1]
+		case yaml.MappingNode:
+			for i, n := range parent.Content {
+				if i % 2 > 0 {
+					continue
+				}
+				if n.Value == key {
+					var nodes []*yaml.Node
+					if i > 0 {
+						nodes = append(nodes, parent.Content[:i]...)
+					}
+					if (i + 1) < (len(parent.Content) - 1) {
+						nodes = append(nodes, parent.Content[i+2:]...)
+					}
+					parent.Content = nodes
+					break
+				}
+			}
+		}
+
+	} else if !vx.IsValid() && vy.IsValid() {
+		// add
+		out, _ := yaml.Marshal(vy.Interface())
+		var node yaml.Node
+		yaml.Unmarshal(out, &node)
+
+		switch parent.Kind {
+		case yaml.DocumentNode:
+			parent.Content = []*yaml.Node{node.Content[0]}
+		case yaml.SequenceNode:
+			var nodes []*yaml.Node
+			index, _ := strconv.Atoi(key)
+			if index > 0 {
+				nodes = append(nodes, parent.Content[:index]...)
+			}
+			nodes = append(nodes, node.Content...)
+			if index < len(parent.Content) {
+				nodes = append(nodes, parent.Content[index:]...)
+			}
+			parent.Content = nodes
+		case yaml.MappingNode:
+			keyNode := yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Tag:         "!!str",
+				Value:       key,
+			}
+			parent.Content = append(parent.Content, &keyNode, node.Content[0])
+		}
+
+	}
+}
+
+func (t *Traversal) PopStep() {
+	t.popState()
+}


### PR DESCRIPTION
This adds the `yamlPatch` provisioner that is similar to `textReplace` but instead applies JSONPatch against the YAML(and JSON as any JSON is a valid YAML) file.

This should be useful in for updating specific keys in a large YAML like ocassionally seen when using `helm` and `helmfile`:

**helmfile.yaml**
```yaml
repositories:
  - name: stable
    url: https://kubernetes-charts.storage.googleapis.com

releases:
- name: datadog-agent
  chart: stable/datadog
  version: 1.37.0
```

**variantdev.mod**
```
provisioners:
  yaml:
    helmfile.yaml:
      - {"op": "replace", "path": "/releases/0/version", "value": "{{ .chart.version }}"}

dependencies:
  chart:
    releasesFrom:
      exec:
        command: sh
        args:
        - -c
        - 'helm search stable/datadog -l | sed 1d | cut -f2'
    version: "> 1.0"
```

NOTE: Modified YAML Node to avoid erasing comments in YAML files. Before and after applying JSON Patch is compared with`go-cmp` and the difference is applied to the YAML Node.