### PR TITLE
fixes YAML format breaking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
 	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0 // indirect

--- a/pkg/yamlpatch/marshal.go
+++ b/pkg/yamlpatch/marshal.go
@@ -1,0 +1,16 @@
+package yamlpatch
+
+import (
+	"bytes"
+	"gopkg.in/yaml.v3"
+)
+
+func (p *YAMLPatch) Marshal() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(p.indent)
+	if err := enc.Encode(p.node); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/yamlpatch/new.go
+++ b/pkg/yamlpatch/new.go
@@ -1,0 +1,41 @@
+package yamlpatch
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+type YAMLPatch struct {
+	node *yaml.Node
+	indent int
+}
+
+func getIndent(node *yaml.Node) int {
+	if node.Kind == yaml.ScalarNode {
+		return 0
+	}
+	if node.Column != 1 {
+		if node.Kind == yaml.SequenceNode {
+			return (node.Column - 1) * 2
+		}
+		return node.Column - 1
+	}
+	for _, content := range node.Content {
+		indent := getIndent(content)
+		if indent > 1 {
+			return indent
+		}
+	}
+	return 0
+}
+
+func New(b []byte) (*YAMLPatch, error) {
+	var yml yaml.Node
+	if err := yaml.Unmarshal(b, &yml); err != nil {
+		return nil, err
+	}
+
+	return &YAMLPatch{
+		node: &yml,
+		indent: getIndent(&yml),
+	}, nil
+}

--- a/pkg/yamlpatch/patch.go
+++ b/pkg/yamlpatch/patch.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
 )
 
-func Patch(y *yaml.Node, patchJSON string) error {
+func (p *YAMLPatch) Patch(patchJSON string) error {
 	var v1 interface{}
-	if err := y.Decode(&v1); err != nil {
+	if err := p.node.Decode(&v1); err != nil {
 		return err
 	}
 
@@ -34,7 +33,7 @@ func Patch(y *yaml.Node, patchJSON string) error {
 	}
 
 	t := &Traversal{stack: []interface{}{}}
-	t.pushState(y, nil, "$")
+	t.pushState(p.node, nil, "$")
 	cmp.Equal(v1, v2, cmp.Reporter(t))
 
 	return nil

--- a/pkg/yamlpatch/patch_test.go
+++ b/pkg/yamlpatch/patch_test.go
@@ -4,22 +4,20 @@ import (
 	"github.com/kylelemons/godebug/diff"
 	_ "github.com/kylelemons/godebug/diff"
 	"github.com/variantdev/mod/pkg/yamlpatch"
-	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 )
 
 func Patch(yml string, jsonPatch string, expected string) string {
-	var node yaml.Node
-	if err := yaml.Unmarshal([]byte(yml), &node); err != nil {
+	p, err := yamlpatch.New([]byte(yml))
+	if err != nil {
+		panic(err)
+	}
+	if err := p.Patch(jsonPatch); err != nil {
 		panic(err)
 	}
 
-	if err := yamlpatch.Patch(&node, jsonPatch); err != nil {
-		panic(err)
-	}
-
-	out, err := yaml.Marshal(node.Content[0])
+	out, err := p.Marshal()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/yamlpatch/traversal.go
+++ b/pkg/yamlpatch/traversal.go
@@ -90,6 +90,12 @@ func (t *Traversal) Report(rs cmp.Result) {
 		out, _ := json.Marshal(vy.Interface())
 		var node yaml.Node
 		yaml.Unmarshal(out, &node)
+		if yml.Kind == node.Content[0].Kind {
+			yml.Tag = node.Content[0].Tag
+			yml.Value = node.Content[0].Value
+			yml.Content = node.Content[0].Content
+			return
+		}
 		yml.Kind = node.Content[0].Kind
 		yml.Style = node.Content[0].Style
 		yml.Tag = node.Content[0].Tag


### PR DESCRIPTION
## problem

I found that the YAML format is broken by `yamlPath`.

- Indent
- Blank line
- String style

### before mod provision
```yaml
repositories:
- name: chatwork
  url: https://chatwork.github.io/charts

environments:
  "{{ .Environment.Name }}":
    values:
    - environments/values.yaml.gotmpl
    - environments/charts/values.yaml.gotmpl
    - environments/clusters/values.yaml.gotmpl

helmDefaults:
  force: true

releases:
- name: regcred
  labels:
    tier: "regcred"
    component: "dockerconfigjson"
    default: "true"
  chart: "{{ .Environment.Values.chartPrefix }}chatwork/regcred"
  version: 0.1.0
  installed: "{{ .Environment.Values.regcred | default false }}"
  values:
  - username: '{{ env "DOCKER_USERNAME" }}'
    password: '{{ env "DOCKER_SECRET" }}'
```

### after mod provision

```yaml
repositories:
  - name: "chatwork"
    url: "https://chatwork.github.io/charts"
environments:
    "{{ .Environment.Name }}":
        values:
          - "environments/values.yaml.gotmpl"
          - "environments/charts/values.yaml.gotmpl"
          - "environments/clusters/values.yaml.gotmpl"
helmDefaults:
    force: true
releases:
  - name: "regcred"
    labels:
        tier: "regcred"
        component: "dockerconfigjson"
        default: "true"
    chart: "{{ .Environment.Values.chartPrefix }}chatwork/regcred"
    version: "0.1.1"
    installed: "{{ .Environment.Values.regcred | default false }}"
    values:
      - username: "{{ env \"DOCKER_USERNAME\" }}"
        password: "{{ env \"DOCKER_SECRET\" }}"
```

## after fixed

```yaml
repositories:
- name: chatwork
  url: https://chatwork.github.io/charts
environments:
  "{{ .Environment.Name }}":
    values:
    - environments/values.yaml.gotmpl
    - environments/charts/values.yaml.gotmpl
    - environments/clusters/values.yaml.gotmpl
helmDefaults:
  force: true
releases:
- name: regcred
  labels:
    tier: "regcred"
    component: "dockerconfigjson"
    default: "true"
  chart: "{{ .Environment.Values.chartPrefix }}chatwork/regcred"
  version: 0.1.1
  installed: "{{ .Environment.Values.regcred | default false }}"
  values:
  - username: '{{ env "DOCKER_USERNAME" }}'
    password: '{{ env "DOCKER_SECRET" }}'
```

NOTE: There was no way to maintain blank lines in `yaml.v3`.