### PR TITLE
Supports skip when PR dupulicate

### DIFF
--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"github.com/variantdev/mod/pkg/cmdsite"
 	"os"
+	"strings"
 )
 
 type Client struct {
@@ -69,6 +70,18 @@ func (c *Client) Push(branch string) error {
 func (c *Client) DiffExists() bool {
 	_, _, err := c.sh.CaptureStrings(c.gitPath, []string{"diff", "--cached", "--exit-code"})
 	return err != nil
+}
+
+func (c *Client) Repo() (string, error) {
+	push, err := c.GetPushURL("origin")
+	if err != nil {
+		return "", err
+	}
+	p := strings.TrimSpace(push)
+	p = strings.TrimSuffix(p, ".git")
+	p = strings.TrimPrefix(p, "git@github.com:")
+	p = strings.TrimPrefix(p, "https://github.com/")
+	return p, nil
 }
 
 func (c *Client) git(cmd string, args []string) error {

--- a/pkg/gitrepo/gitrepo.go
+++ b/pkg/gitrepo/gitrepo.go
@@ -1,0 +1,125 @@
+package gitrepo
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-github/v27/github"
+	"golang.org/x/oauth2"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Client struct {
+	github *github.Client
+}
+
+type NewRepositoryOption struct {
+	Private bool
+	TemplateOwner string
+	TemplateRepo string
+}
+
+func (c *Client) NewRepository(ctx context.Context, owner string, repo string, opt *NewRepositoryOption) (*github.Repository, error) {
+	req := github.TemplateRepoRequest{
+		Name:    &owner,
+		Owner:   &repo,
+		Private: &opt.Private,
+	}
+	createdRepo, _, err := c.github.Repositories.CreateFromTemplate(ctx, opt.TemplateOwner, opt.TemplateRepo, &req)
+	return createdRepo, err
+}
+
+type Query struct {
+	State string
+	Body string
+	Title string
+}
+
+func (q *Query) Filtter(issues []github.Issue) []*github.Issue {
+	result := make([]*github.Issue, 0)
+	for _, issue := range issues {
+		if issue.GetState() == q.State {
+			result = append(result, &issue)
+			continue
+		}
+		if issue.GetBody() == q.Body {
+			result = append(result, &issue)
+			continue
+		}
+		if issue.GetTitle() == q.Title {
+			result = append(result, &issue)
+			continue
+		}
+	}
+	return result
+}
+
+func (q *Query) String() string {
+	arr := make([]string, 0)
+	if q.State != "" {
+		arr = append(arr, fmt.Sprintf("is:%s", q.State))
+	}
+	if q.Body != "" {
+		arr = append(arr, fmt.Sprintf("%s in:body", strconv.Quote(strings.Replace(q.Body, "\n", " ", -1))))
+	}
+	if q.Title != "" {
+		arr = append(arr, fmt.Sprintf("%s in:title", strconv.Quote(q.Title)))
+	}
+	return strings.Join(arr, " ")
+}
+
+func (c *Client) SearchIssues(ctx context.Context, owner string, repo string, query *Query) ([]*github.Issue, error) {
+	q := fmt.Sprintf("is:pr repo:%s/%s %s", owner, repo, query.String())
+	searchOpt := &github.SearchOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+	result, resp, err := c.github.Search.Issues(ctx, q, searchOpt)
+	if err != nil {
+		return nil, err
+	}
+	issues := query.Filtter(result.Issues)
+	for resp.NextPage > searchOpt.Page {
+		searchOpt.Page = resp.NextPage
+		r, res, err := c.github.Search.Issues(ctx, q, searchOpt)
+		if err != nil {
+			return nil, err
+		}
+		issues = append(issues, query.Filtter(r.Issues)...)
+		resp = res
+	}
+	return issues, nil
+}
+
+type NewPullRequestOptions struct {
+	Title string
+	Head string
+	Base string
+	Body string
+}
+
+func (c *Client) NewPullRequest(ctx context.Context, owner string, repo string, opt *NewPullRequestOptions) (*github.PullRequest, error) {
+	newPr := github.NewPullRequest{
+		Title: &opt.Title,
+		Head:  &opt.Head,
+		Base:  &opt.Base,
+		Body:  &opt.Body,
+	}
+	pr, _, err := c.github.PullRequests.Create(ctx, owner, repo, &newPr)
+
+	return pr, err
+}
+
+func NewClient(ctx context.Context) *Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	gc := github.NewClient(tc)
+
+	return &Client{
+		github: gc,
+	}
+}

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -2,6 +2,8 @@ package tmpl
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"text/template"
@@ -20,6 +22,10 @@ func Render(name, text string, data interface{}) (string, error) {
 		},
 		"trimSpace": func(s string) string {
 			return strings.TrimSpace(s)
+		},
+		"sha256": func(s string) string {
+			b := sha256.Sum256([]byte(s))
+			return hex.EncodeToString(b[:])
 		},
 	}
 	tpl := template.New(name).Option("missingkey=error").Funcs(funcs)

--- a/pkg/variantmod/manager.go
+++ b/pkg/variantmod/manager.go
@@ -6,18 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-logr/logr"
-	"github.com/google/go-github/v27/github"
 	"github.com/twpayne/go-vfs"
 	"github.com/variantdev/mod/pkg/cmdsite"
 	"github.com/variantdev/mod/pkg/depresolver"
 	"github.com/variantdev/mod/pkg/execversionmanager"
 	"github.com/variantdev/mod/pkg/gitops"
+	"github.com/variantdev/mod/pkg/gitrepo"
 	"github.com/variantdev/mod/pkg/maputil"
 	"github.com/variantdev/mod/pkg/releasetracker"
 	"github.com/variantdev/mod/pkg/tmpl"
 	"github.com/variantdev/mod/pkg/yamlpatch"
 	"github.com/xeipuuv/gojsonschema"
-	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
@@ -251,12 +250,13 @@ func (m *ModuleManager) LoadLockFile() (*ModVersionLock, error) {
 		}
 	}
 
-	lockContents := ModVersionLock{Dependencies: map[string]DepVersionLock{}}
+	lockContents := ModVersionLock{Dependencies: map[string]DepVersionLock{}, RawLock: string(bytes)}
 	if bytes != nil {
 		m.Logger.V(2).Info("load.yaml.unmarshal.begin", "bytes", string(bytes))
 		if err := yaml.Unmarshal(bytes, &lockContents); err != nil {
 			return nil, err
 		}
+		lockContents.RawLock = string(bytes)
 
 		m.Logger.V(2).Info("load.yaml.unmarshal.end", "data", lockContents)
 	}
@@ -634,17 +634,30 @@ func (m *ModuleManager) Push(files []string, branch string) (bool, error) {
 	return false, nil
 }
 
-func (m *ModuleManager) PullRequest(title, base, head string) error {
-	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	gc := github.NewClient(tc)
-
-
+func (m *ModuleManager) PullRequest(title, body, base, head string, skipDuplicatePRBody, skipDuplicatePRTitle bool) error {
 	mod, err := m.Load()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	gc := gitrepo.NewClient(ctx)
+
+	g := gitops.New(
+		gitops.WD(m.AbsWorkDir),
+		gitops.Commander(m.cmdr),
+	)
+	r, err := g.Repo()
+	if err != nil {
+		return err
+	}
+	ownerRepo := strings.Split(r, "/")
+	if len(ownerRepo) != 2 {
+		return fmt.Errorf("unexpected format of remote: %s", r)
+	}
+	owner := ownerRepo[0]
+	repo := ownerRepo[1]
+
+	b, err:= tmpl.Render("body", body, mod.Values)
 	if err != nil {
 		return err
 	}
@@ -653,37 +666,32 @@ func (m *ModuleManager) PullRequest(title, base, head string) error {
 		return err
 	}
 
-	body := ``
-	newPr := github.NewPullRequest{
-		Title: &t,
-		Head:  &head,
-		Base:  &base,
-		Body:  &body,
+	if skipDuplicatePRBody || skipDuplicatePRTitle {
+		query := &gitrepo.Query{State: "open"}
+		if skipDuplicatePRBody {
+			query.Body = b
+		}
+		if skipDuplicatePRTitle {
+			query.Title = t
+		}
+		issues, err := gc.SearchIssues(ctx, owner, repo, query)
+		if err != nil {
+			return err
+		}
+		if len(issues) > 0 {
+			klog.V(0).Infof("skipped due to duplicate pull request: #%d", issues[0].GetNumber())
+			return nil
+		}
 	}
 
-	g := gitops.New(
-		gitops.WD(m.AbsWorkDir),
-		gitops.Commander(m.cmdr),
-	)
-	push, err := g.GetPushURL("origin")
+	newPr := gitrepo.NewPullRequestOptions{
+		Title: t,
+		Head:  head,
+		Base:  base,
+		Body:  b,
+	}
+	pr, err := gc.NewPullRequest(ctx, owner, repo, &newPr)
 	if err != nil {
-		return err
-	}
-
-	p := strings.TrimSpace(push)
-	p = strings.TrimSuffix(p, ".git")
-	p = strings.TrimPrefix(p, "git@github.com:")
-	p = strings.TrimPrefix(p, "https://github.com/")
-	ownerRepo := strings.Split(p, "/")
-	if len(ownerRepo) != 2 {
-		return fmt.Errorf("unexpected format of remote: %s", push)
-	}
-	owner := ownerRepo[0]
-	repo := ownerRepo[1]
-
-	pr, res, err := gc.PullRequests.Create(ctx, owner, repo, &newPr)
-	if err != nil {
-		klog.V(1).Infof("create pull request: %v", res)
 		return fmt.Errorf("create pull request: %v", err)
 	}
 
@@ -694,17 +702,8 @@ func (m *ModuleManager) PullRequest(title, base, head string) error {
 
 func (m *ModuleManager) Create(templateRepo, newRepo string, public bool) error {
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
-	)
-	tc := oauth2.NewClient(ctx, ts)
 
-	gc := github.NewClient(tc)
-
-	g := gitops.New(
-		gitops.WD(m.AbsWorkDir),
-		gitops.Commander(m.cmdr),
-	)
+	gc := gitrepo.NewClient(ctx)
 
 	t := strings.TrimSuffix(templateRepo, ".git")
 	t = strings.TrimPrefix(t, "git@github.com:")
@@ -726,20 +725,22 @@ func (m *ModuleManager) Create(templateRepo, newRepo string, public bool) error 
 
 	private := !public
 
-	req := github.TemplateRepoRequest{
-		Name:    &nRepo,
-		Owner:   &nOwner,
-		Private: &private,
+	opt := &gitrepo.NewRepositoryOption{
+		Private:       private,
+		TemplateOwner: tOwner,
+		TemplateRepo:  tRepo,
 	}
-
-	createdRepo, res, err := gc.Repositories.CreateFromTemplate(ctx, tOwner, tRepo, &req)
+	createdRepo, err := gc.NewRepository(ctx, nOwner, nRepo, opt)
 	if err != nil {
-		klog.V(1).Infof("create repository from template: %v", res)
 		return fmt.Errorf("create repository from template: %v", err)
 	}
 
 	klog.V(2).Infof("repository created: %+v", createdRepo)
 
+	g := gitops.New(
+		gitops.WD(m.AbsWorkDir),
+		gitops.Commander(m.cmdr),
+	)
 	if err := g.Clone("git@github.com:" + newRepo); err != nil {
 		return err
 	}

--- a/pkg/variantmod/module.go
+++ b/pkg/variantmod/module.go
@@ -30,6 +30,7 @@ type Module struct {
 
 type ModVersionLock struct {
 	Dependencies map[string]DepVersionLock `yaml:"dependencies"`
+	RawLock string `yaml:"-"`
 }
 
 type DepVersionLock struct {
@@ -38,7 +39,7 @@ type DepVersionLock struct {
 }
 
 func (l ModVersionLock) ToMap() map[string]interface{} {
-	return map[string]interface{}{"Dependencies": l.ToDepsMap()}
+	return map[string]interface{}{"Dependencies": l.ToDepsMap(), "RawLock": l.RawLock}
 }
 
 func (l ModVersionLock) ToDepsMap() map[string]interface{} {


### PR DESCRIPTION
There is a problem that PR is created every time mod is executed
Therefore, I changed so that PR creation is skipped when either the PR title or PR body duplicate.

```
$ mod up --help
Usage:
  mod up [flags]

Flags:
      --base string                         Branch to which pull request is sent to (default "master")
      --body string                         Title of the pull-request to be sent (default "{{ .RawLock | sha256 }}")
      --branch string                       Prefix of git branch name to which the provisioned files are pushed (default "mod-up")
      --build build                         Run build after update
  -h, --help                                help for up
      --pull-request                        Send a pull request after push. Implies --push
      --push build                          Push to Git repository after update (and build if --build provided)
      --repo string                         Git repository to which the provisioned files are pushed
      --skip-duplicate-pull-request-body    If true, PR creation will be skipped if the PR body is duplicated.
      --skip-duplicate-pull-request-title   If true, PR creation will be skipped if the PR title is duplicated.
      --title string                        Title of the pull-request to be sent (default "Update dependencies")
```
