### PR TITLE
fixes docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 ARG MOD_VERSION
 


### PR DESCRIPTION
The docker hub build failed on the master branch.
Therefore, the new version of docker image was not pushed.